### PR TITLE
Add wofi as finder for bookmarks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -702,7 +702,7 @@ fn expand_tilde(path: &str) -> PathBuf {
 }
 
 fn validate_path(relative_path: &str) {
-  let re = Regex::new(r"^[a-zA-Z0-9_/.-]+$").panic_on_error("Invalid path");
+  let re = Regex::new(r"^[a-zåäöA-ZÅÄÖ0-9_/.-]+$").panic_on_error("Invalid path");
   if !re.is_match(relative_path) {
     panic!("Invalid path. Please avoid spaces and special characters.");
   }


### PR DESCRIPTION
Add support for [wofi](https://github.com/SimplyCEO/wofi) which is a graphical fuzzy finder. I've implement the support as a config option in the .toml and the init will ask if you want to use the default (fzf) or wofi.

Example screenshot:
![screenshot_2025-04-09_213434](https://github.com/user-attachments/assets/f909447f-2908-46f9-a32e-5fc07a43f4f5)

This PR also adds support for swedish characters in the bookmark path name.