### PR TITLE
Enable TEMPESTA_CONFIG environment variable & Add integration tests for init / add / move / remove

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "2.6.0"
+name = "anstyle"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -68,6 +101,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,10 +139,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "equivalent"
-version = "1.0.1"
+name = "doc-comment"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "form_urlencoded"
@@ -116,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -281,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -323,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libredox"
@@ -363,9 +408,9 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "objc2"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3531f65190d9cff863b77a99857e74c314dd16bf56c538c4b57c7cbc3f3a6e59"
+checksum = "88c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551"
 dependencies = [
  "objc2-encode",
 ]
@@ -378,9 +423,9 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a21c6c9014b82c39515db5b396f91645182611c97d24637cf56ac01e5f8d998"
+checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
 dependencies = [
  "bitflags",
  "objc2",
@@ -405,19 +450,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.92"
+name = "predicates"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -473,18 +545,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -514,9 +586,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.91"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -538,12 +610,19 @@ dependencies = [
 name = "tempesta"
 version = "0.0.78"
 dependencies = [
+ "assert_cmd",
  "dirs",
  "regex",
  "serde",
  "toml",
  "webbrowser",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -631,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "url"
@@ -657,6 +736,15 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -908,9 +996,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ dirs = "6.0"
 webbrowser = "1.0.4"
 toml = "0.8"
 regex = "1"
+assert_cmd = "2.0.17"
 
 [package.metadata.release]
 push = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -533,14 +536,18 @@ fn edit(args: Vec<String>) {
 }
 
 fn get_config_file_path() -> PathBuf {
-  let home_dir =
-    dirs::home_dir().panic_on_error("Could not find home directory");
-  let mut config_path = home_dir;
-  config_path.push(".config/tempesta");
-  fs::create_dir_all(&config_path)
-    .panic_on_error("Failed to create config directory");
-  config_path.push("tempesta.toml");
-  config_path
+  if env::var("TEMPESTA_CONFIG").is_ok() {
+    PathBuf::from(env::var("TEMPESTA_CONFIG").unwrap())
+  } else {
+    let home_dir =
+      dirs::home_dir().panic_on_error("Could not find home directory");
+    let mut config_path = home_dir;
+    config_path.push(".config/tempesta");
+    fs::create_dir_all(&config_path)
+      .panic_on_error("Failed to create config directory");
+    config_path.push("tempesta.toml");
+    config_path
+  }
 }
 
 fn load_config() -> Config {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,72 @@
+// use crate::add;
+use assert_cmd::Command;
+use std::env;
+use std::path::PathBuf;
+
+fn test_env() -> PathBuf {
+  let mut tempesta_config =
+    PathBuf::from(env::var("HOME").expect("HOME environment variable not set"));
+  tempesta_config.push(".config/tempesta/test.toml");
+  env::set_var("TEMPESTA_CONFIG", tempesta_config);
+  PathBuf::from(env::var("HOME").expect("HOME environment variable not set"))
+}
+
+#[test]
+fn tempesta_init() {
+  let home = test_env();
+  let output = "Where do you want to store the bookmarks? [~/.bookmark-store]: Do you want to use Git for tracking bookmarks? (Y/n): Tempesta initialized successfully: HOME/.config/tempesta/test.toml\n"
+        .replace("HOME", home.to_str().expect("Unable to convert HOME dir to str"));
+  Command::cargo_bin("tempesta")
+    .unwrap()
+    .arg("init")
+    .write_stdin("~/.bookmark-store-test\nno\n")
+    .assert()
+    .success()
+    .stdout(output);
+  //TODO: assert file is created and looks as expected
+}
+
+#[test]
+fn tempesta_add_overwrite_move_remove() {
+  let home = test_env();
+
+  // add
+  let output_add = "Bookmark file stored at HOME/.bookmark-store-test/test.toml\nBookmark added successfully as test\n"
+        .replace("HOME", home.to_str().expect("Unable to convert HOME dir to str"));
+  Command::cargo_bin("tempesta")
+    .unwrap()
+    .args(["add", "test", "https://test.local", "test"])
+    .assert()
+    .success()
+    .stdout(output_add);
+
+  // add (again but this time overwrite)
+  let output_add_overwrite = "Bookmark already exists at HOME/.bookmark-store-test/test.toml. Overwrite? (y/N): Overwriting file...\nBookmark file stored at HOME/.bookmark-store-test/test.toml\nBookmark added successfully as test\n"
+        .replace("HOME", home.to_str().expect("Unable to convert HOME dir to str"));
+  Command::cargo_bin("tempesta")
+    .unwrap()
+    .args(["add", "test", "https://test.local", "test"])
+    .write_stdin("y\n")
+    .assert()
+    .success()
+    .stdout(output_add_overwrite);
+
+  // move
+  let output_move = "Bookmark moved successfully from test to move/test\n";
+  Command::cargo_bin("tempesta")
+    .unwrap()
+    .args(["move", "test", "move/test"])
+    .assert()
+    .success()
+    .stdout(output_move);
+
+  // remove (removing the last entry in the bookmark-store-test removes it completely)
+  let output_remove = "Bookmark removed successfully as move/test\n";
+  Command::cargo_bin("tempesta")
+    .unwrap()
+    .args(["remove", "move/test"])
+    .assert()
+    .success()
+    .stdout(output_remove);
+  // TODO: cleanup ~/.config/tempesta/tempesta.toml
+}


### PR DESCRIPTION
This partially solves #10 and makes it so that the cargo test command can be run without overwriting the current tempesta config.